### PR TITLE
add span.kind as a tag in PDO, redis extensions

### DIFF
--- a/src/Trace/Integrations/PDO.php
+++ b/src/Trace/Integrations/PDO.php
@@ -71,7 +71,7 @@ class PDO implements IntegrationInterface
     public static function handleQuery($pdo, $query)
     {
         return [
-            'attributes' => ['db.statement' => $query],
+            'attributes' => ['db.statement' => $query, 'span.kind' => Span::KIND_CLIENT],
             'kind' => Span::KIND_CLIENT
         ];
     }
@@ -86,7 +86,7 @@ class PDO implements IntegrationInterface
      */
     public static function handleConnect($pdo, $dsn)
     {
-        $attributes = ['dsn' => $dsn, 'db.type' => 'sql'];
+        $attributes = ['dsn' => $dsn, 'db.type' => 'sql', 'span.kind' => Span::KIND_CLIENT];
 
         return [ 'attributes' => $attributes,
             'kind' => Span::KIND_CLIENT,
@@ -153,7 +153,11 @@ class PDO implements IntegrationInterface
             $errorTags['error.message'] = $errorCodeMsgArray[$error] ?? '';
         }
 
-        $tags = ['db.statement' => $statement->queryString, 'db.row_count' => $rowCount];
+        $tags = [
+            'db.statement' => $statement->queryString,
+            'db.row_count' => $rowCount,
+            'span.kind' => Span::KIND_CLIENT
+        ];
 
         return [
             'attributes' => $tags + $errorTags,

--- a/src/Trace/Integrations/Redis.php
+++ b/src/Trace/Integrations/Redis.php
@@ -56,7 +56,8 @@ class Redis implements IntegrationInterface
                     'attributes' => [
                         'peer.hostname' => $params['host'],
                         'peer.port' => $params['port'],
-                        'db.type' => 'redis'
+                        'db.type' => 'redis',
+                        'span.kind' => Span::KIND_CLIENT
                     ],
                     'kind' => Span::KIND_CLIENT
                 ];
@@ -71,7 +72,8 @@ class Redis implements IntegrationInterface
                         'command' => $command->getId(),
                         'service.name' => 'redis',
                         'redis.raw_command' => $query,
-                        'redis.args_length' => count($arguments)
+                        'redis.args_length' => count($arguments),
+                        'span.kind' => Span::KIND_CLIENT
                     ],
                     'kind' => Span::KIND_CLIENT
                 ];


### PR DESCRIPTION
To enable service view in hypertarace. 
Following suggestion from [opentracing spec](https://github.com/opentracing/specification/blob/master/semantic_conventions.md#span-tags-table) to add it as a tag. 
