### PR TITLE
Fix extraction from headers

### DIFF
--- a/src/Trace/Propagator/JaegerPropagator.php
+++ b/src/Trace/Propagator/JaegerPropagator.php
@@ -69,6 +69,8 @@ class JaegerPropagator implements PropagatorInterface
             return new SpanContext();
         }
         
+        // Jaeger trace id can be of length either 16 or 32. (https://www.jaegertracing.io/docs/1.21/client-libraries/#value)
+        // We have decided to continue with trace id of length 32 for injection. While extraction can accept both length 16 and 32.
         $data = explode($data, ':');
         if (count($data) < 4) {
             return new SpanContext();

--- a/src/Trace/Propagator/JaegerPropagator.php
+++ b/src/Trace/Propagator/JaegerPropagator.php
@@ -68,12 +68,16 @@ class JaegerPropagator implements PropagatorInterface
         if (!$data) {
             return new SpanContext();
         }
-
-        $n = sscanf($data, self::CONTEXT_HEADER_FORMAT, $traceId, $spanId, $parentSpanId, $flags);
-
-        if ($n == 0) {
+        
+        $data = explode($data, ':');
+        if (count($data) < 4) {
             return new SpanContext();
         }
+        
+        $traceId = $data[0];
+        $spanId = $data[1];
+        $parentSpanId = $data[2];
+        $flags = $data[3];
 
         $enabled = $flags & 0x01;
 


### PR DESCRIPTION
#### What
- Jaeger trace id can be of length either 16 or 32. [Reference](https://www.jaegertracing.io/docs/1.21/client-libraries/#value). Currently if the client had sent a trace id of length 16, the extraction process breaks because jaegerPropogator is expecting a trace id of length 32 always. As a result, the tracing would break.
- We have decided to continue with trace id of length 32 for injection. While extraction can accept both length 16 and 32.