### PR TITLE
fix redis and database tags

### DIFF
--- a/src/Trace/Integrations/Redis.php
+++ b/src/Trace/Integrations/Redis.php
@@ -61,7 +61,6 @@ class Redis implements IntegrationInterface
                     'db.type' => 'redis',
                     'db.system' => 'redis',
                     'db.connection_string' =>  $connection_str,
-                    'redis.connection' => $connection_str,
                     'span.kind' => Span::KIND_CLIENT
                 ],
                 'kind' => Span::KIND_CLIENT,


### PR DESCRIPTION
1. remove non standard redis.connection tag, blocking redis to be recognized as backend
2. for mysql dsn without host, take host as an optional param to PDO load

with this fix, API shows up with db and redis backends in HT
<img width="875" alt="Screenshot 2021-03-01 at 9 52 57 PM" src="https://user-images.githubusercontent.com/8813/109526426-8c483880-7ad8-11eb-9477-8272ec7edebe.png">
