### PR TITLE
Add PMG (Package Manager Guard) to CI workflows

### DIFF
--- a/.github/workflows/build_images.yml
+++ b/.github/workflows/build_images.yml
@@ -5,6 +5,18 @@ jobs:
     name: Cancel Previous Runs
     if: always()
     steps:
+      # PMG (Package Manager Guard) blocks malicious packages at install time.
+      # Must come after every language/toolchain setup action so its shims land
+      # first on PATH. See https://docs.safedep.io/package-security/pmg/github-actions
+      # This job installs nothing today; the guard is here so any package manager
+      # added later is covered by default.
+      - name: Set up PMG
+        uses: safedep/pmg@v1
+        with:
+          server-mode: true
+          api-key: ${{ secrets.SAFEDEP_API_KEY }}
+          tenant-id: ${{ secrets.SAFEDEP_TENANT_ID }}
+
       - uses: styfle/cancel-workflow-action@d57d93c3a8110b00c3a2c0b64b8516013c9fd4c9
         if: github.ref != 'refs/heads/master'
         name: cancel old workflows
@@ -17,6 +29,12 @@ jobs:
         id: dont_cancel
         run: |
           echo "Don't cancel old workflow"
+
+      # Must run even when earlier steps fail, otherwise the job won't fail on a
+      # policy violation and the most recent events are never flushed.
+      - name: Enforce PMG policy
+        if: always()
+        run: pmg proxy stop --fail-on-violation
   build-web:
     name: Extension Build
     runs-on: ubuntu-latest
@@ -25,6 +43,19 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v2
+
+      # PMG (Package Manager Guard) blocks malicious packages at install time.
+      # Must come after every language/toolchain setup action so its shims land
+      # first on PATH. See https://docs.safedep.io/package-security/pmg/github-actions
+      # Note: PMG only sees package managers run on the runner, not those run
+      # inside `docker build`. Dockerfile.rzp installs no packages today.
+      - name: Set up PMG
+        uses: safedep/pmg@v1
+        with:
+          server-mode: true
+          api-key: ${{ secrets.SAFEDEP_API_KEY }}
+          tenant-id: ${{ secrets.SAFEDEP_TENANT_ID }}
+
       - name: Login to Dockerhub
         uses: docker/login-action@v1
         with:
@@ -40,3 +71,8 @@ jobs:
           dockerfile: Dockerfile.rzp
           build_args: GIT_COMMIT_HASH=${{ github.sha }},GIT_TOKEN=${{ secrets.GIT_ACTION_TOKEN }},GIT_USERNAME=rzp
 
+      # Must run even when earlier steps fail, otherwise the job won't fail on a
+      # policy violation and the most recent events are never flushed.
+      - name: Enforce PMG policy
+        if: always()
+        run: pmg proxy stop --fail-on-violation

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,16 @@ jobs:
           php-version: "${{ matrix.php }}"
           coverage: xdebug
 
+      # PMG (Package Manager Guard) blocks malicious packages at install time.
+      # Must come after every language/toolchain setup action so its shims land
+      # first on PATH. See https://docs.safedep.io/package-security/pmg/github-actions
+      - name: Set up PMG
+        uses: safedep/pmg@v1
+        with:
+          server-mode: true
+          api-key: ${{ secrets.SAFEDEP_API_KEY }}
+          tenant-id: ${{ secrets.SAFEDEP_TENANT_ID }}
+
       - name: Install build tools
         run: |
           autoconf -V || \
@@ -86,6 +96,12 @@ jobs:
           files: build/clover.xml
           verbose: true
 
+      # Must run even when earlier steps fail, otherwise the job won't fail on a
+      # policy violation and the most recent events are never flushed.
+      - name: Enforce PMG policy
+        if: always()
+        run: pmg proxy stop --fail-on-violation
+
   integration:
     runs-on: ubuntu-latest
     env:
@@ -106,6 +122,16 @@ jobs:
           php-version: 8.0
           extensions: memcached, pdo_mysql, mysqli, pdo_pgsql, pcntl
           ini-values: extension=opencensus.so
+
+      # PMG (Package Manager Guard) blocks malicious packages at install time.
+      # Must come after every language/toolchain setup action so its shims land
+      # first on PATH. See https://docs.safedep.io/package-security/pmg/github-actions
+      - name: Set up PMG
+        uses: safedep/pmg@v1
+        with:
+          server-mode: true
+          api-key: ${{ secrets.SAFEDEP_API_KEY }}
+          tenant-id: ${{ secrets.SAFEDEP_TENANT_ID }}
 
       - uses: niden/actions-memcached@v7
 
@@ -151,6 +177,11 @@ jobs:
             files: build/clover.xml
             verbose: true
 
+      # Must run even when earlier steps fail, otherwise the job won't fail on a
+      # policy violation and the most recent events are never flushed.
+      - name: Enforce PMG policy
+        if: always()
+        run: pmg proxy stop --fail-on-violation
 
     services:
       mysql:


### PR DESCRIPTION
## What

Wires [PMG](https://docs.safedep.io/package-security/pmg/github-actions) (SafeDep Package Manager Guard) into every job across this repo's workflows where GitHub Actions permits it, so malicious packages are blocked at install time.

| Workflow / job | PMG | Why |
|---|---|---|
| `ci.yml` / `build` | ✅ | Guards `composer install` |
| `ci.yml` / `integration` | ✅ | Guards `composer install` / `create-project` / `require` inside the integration test scripts |
| `build_images.yml` / `cancel` | ✅ | No installs today — added for future coverage |
| `build_images.yml` / `build-web` | ✅ | No installs today — added for future coverage |
| `genesis.yml` / `Analysis` | ❌ | Not possible — see below |

## Notes on placement

- **Setup runs after `setup-php`** in `ci.yml`, so PMG's shims land first on `PATH`.
- **Enforce uses `if: always()`** so a policy violation still fails the job when an earlier step fails, and so pending events get flushed.
- **`build_images.yml` gains no coverage today** — nothing runs a package manager on the runner, and PMG cannot see inside `docker build` (its shims are runner-level; `Dockerfile.rzp` only runs `phpize`/`make`). Added regardless so anything introduced later is guarded by default.

## Why `genesis.yml` is untouched

Its only job calls a reusable workflow (`uses: razorpay/genesis/.github/workflows/quality-checks.yml@master`). GitHub rejects any job that has both `uses:` and `steps:`, so adding PMG there would make the whole workflow fail to parse and the nightly scan would stop running.

Adding PMG as a *separate* job in that file would be valid but useless — each job gets its own runner, so it could never intercept installs in the reusable workflow's runner.

PMG for those checks belongs upstream in `razorpay/genesis` → `quality-checks.yml` → `validation-job`, which would cover every repo calling it. Worth noting there: that job runs under `container: semgrep/semgrep`, so `safedep/pmg@v1` should be verified against a container job first.

## Before merging

⚠️ **`SAFEDEP_API_KEY` and `SAFEDEP_TENANT_ID` must be available to this repo** (repo or org level). Without them the setup step runs uncredentialed and `pmg proxy stop --fail-on-violation` will likely fail every job.

Note this makes `build_images.yml` depend on those secrets to go green where it previously didn't — so it's the image build at risk, not just CI. Confirm the secrets are in place before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)